### PR TITLE
Add structure behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /tmp
 erl_crash.dump
 *.ez
+test.sqlite3

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -58,7 +58,7 @@ defmodule Blog do
     import Supervisor.Spec, warn: false
 
     children = [
-      worker(Blog.Repo, [])
+      Blog.Repo,
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
@@ -67,6 +67,15 @@ defmodule Blog do
     Supervisor.start_link(children, opts)
   end
 end
+```
+
+If `Elixir < 1.5.0`:
+```elixir
+...
+    children = [
+      worker(Blog.Repo, [])
+    ]
+...
 ```
 
 Run `mix ecto.create`.  Verify that the SQLite database has been created at `blog.sqlite3` or wherever you have configured your database to be written.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -16,7 +16,7 @@ def application do
 end
 
 defp deps do
-  [{:sqlite_ecto2, "~> 2.0.0-dev.8"}]
+  [{:sqlite_ecto2, "~> 2.2"}]
 end
 ```
 

--- a/lib/sqlite_db_connection/stream.ex
+++ b/lib/sqlite_db_connection/stream.ex
@@ -22,6 +22,10 @@ defimpl Enumerable, for: Sqlite.DbConnection.Stream do
     end
   end
 
+  def slice(_) do
+    {:error, __MODULE__}
+  end
+
   def member?(_, _) do
     {:error, __MODULE__}
   end

--- a/lib/sqlite_ecto.ex
+++ b/lib/sqlite_ecto.ex
@@ -182,7 +182,7 @@ defmodule Sqlite.Ecto2 do
       Sqlitex.query(db, "SELECT version FROM #{table} ORDER BY version")
     end) do
       {:ok, versions} -> {:ok, versions}
-      {:error, {:sqlite_error, 'no such table: schema_migrations'}} ->
+      {:error, {:sqlite_error, 'no such table: '}} ->
         {:ok, []}
       {:error, error} ->
         {:error, inspect(error)}
@@ -195,10 +195,10 @@ defmodule Sqlite.Ecto2 do
 
     insert =
       versions
-      |> Enum.map(fn version -> version[:version] end)
-      |> Enum.join(", ")
-      |> String.replace_prefix("", "\n\nINSERT INTO #{table} (version) VALUES (")
-      |> String.replace_suffix("", ");\n\n")
+      |> Enum.map(fn version -> "    \"#{version[:version]}\"\n" end)
+      |> Enum.join("), (\n")
+      |> String.replace_prefix("", "INSERT INTO \"#{table}\" (\"version\") VALUES (\n")
+      |> String.replace_suffix("", ");\n")
 
     File.write!(path, content <> insert)
   end

--- a/lib/sqlite_ecto.ex
+++ b/lib/sqlite_ecto.ex
@@ -40,6 +40,7 @@ defmodule Sqlite.Ecto2 do
 
   # And provide a custom storage implementation
   @behaviour Ecto.Adapter.Storage
+  @behaviour Ecto.Adapter.Structure
 
   ## Custom SQLite Types
 
@@ -153,4 +154,22 @@ defmodule Sqlite.Ecto2 do
 
   @doc false
   def supports_ddl_transaction?, do: true
+
+  def structure_load(default, opts) do
+    database = Keyword.fetch!(opts, :database)
+
+    run_cmd("sqlite3 #{database} < #{default}/structure.sql")
+  end
+
+  def structure_dump(default, opts) do
+    database = Keyword.fetch!(opts, :database)
+
+    run_cmd("sqlite3 #{database} .schema > #{default}/structure.sql")
+  end
+
+  defp run_cmd(str) do
+    str
+    |> String.to_charlist()
+    |> :os.cmd()
+  end
 end

--- a/lib/sqlite_ecto.ex
+++ b/lib/sqlite_ecto.ex
@@ -173,7 +173,7 @@ defmodule Sqlite.Ecto2 do
          :ok <- append_versions(table, path, versions) do
       {:ok, path}
     else
-      result -> raise RuntimeError, "#{inspect result}"
+      result -> raise RuntimeError, inspect(result)
     end
   end
 
@@ -185,7 +185,7 @@ defmodule Sqlite.Ecto2 do
       {:error, {:sqlite_error, 'no such table: schema_migrations'}} ->
         {:ok, []}
       {:error, error} ->
-        {:error, "#{inspect error}"}
+        {:error, inspect(error)}
     end
   end
 

--- a/test/sqlite_ecto_test.exs
+++ b/test/sqlite_ecto_test.exs
@@ -1306,6 +1306,29 @@ defmodule Sqlite.Ecto2.Test do
     end
   end
 
+  describe "structure" do
+    test "can be loaded" do
+      Sqlite.Ecto2.structure_load("test/support", database: "test.sqlite3")
+      {:ok, result} = Sqlitex.with_db("test.sqlite3", fn db ->
+        Sqlitex.query(db, "select name from sqlite_master where type = \"table\"")
+      end)
+
+      assert [[name: "test"]] == result
+
+      File.rm! "test.sqlite3"
+    end
+
+    test "can be dumped" do
+      Sqlite.Ecto2.structure_load("./test/support", database: "./test.sqlite3")
+      Sqlite.Ecto2.structure_dump("./", database: "test.sqlite3")
+
+      assert File.read!("./test/support/structure.sql") == File.read!("./structure.sql")
+
+      File.rm! "./test.sqlite3"
+      File.rm! "./structure.sql"
+    end
+  end
+
   defp remove_newlines(string) do
     string |> String.trim |> String.replace("\n", " ")
   end

--- a/test/sqlite_ecto_test.exs
+++ b/test/sqlite_ecto_test.exs
@@ -1320,7 +1320,7 @@ defmodule Sqlite.Ecto2.Test do
 
     test "can be dumped" do
       Sqlite.Ecto2.structure_load("./test/support", database: "./test.sqlite3")
-      Sqlite.Ecto2.structure_dump("./", database: "test.sqlite3")
+      Sqlite.Ecto2.structure_dump("./", database: "./test.sqlite3")
 
       assert File.read!("./test/support/structure.sql") == File.read!("./structure.sql")
 

--- a/test/sqlite_ecto_test.exs
+++ b/test/sqlite_ecto_test.exs
@@ -1313,12 +1313,12 @@ defmodule Sqlite.Ecto2.Test do
         Sqlitex.query(db, "select name from sqlite_master where type = \"table\"")
       end)
 
-      assert [[name: "test"]] == result
+      assert [[name: "test"], [name: "schema_migrations"]] == result
 
       File.rm! "./test.sqlite3"
     end
 
-    test "can be dumped" do
+    test "can be dumped with version table appended" do
       Sqlite.Ecto2.structure_load("./test/support", database: "./test.sqlite3")
       Sqlite.Ecto2.structure_dump("./", database: "./test.sqlite3")
 

--- a/test/sqlite_ecto_test.exs
+++ b/test/sqlite_ecto_test.exs
@@ -1308,14 +1308,14 @@ defmodule Sqlite.Ecto2.Test do
 
   describe "structure" do
     test "can be loaded" do
-      Sqlite.Ecto2.structure_load("test/support", database: "test.sqlite3")
+      Sqlite.Ecto2.structure_load("./test/support", database: "./test.sqlite3")
       {:ok, result} = Sqlitex.with_db("test.sqlite3", fn db ->
         Sqlitex.query(db, "select name from sqlite_master where type = \"table\"")
       end)
 
       assert [[name: "test"]] == result
 
-      File.rm! "test.sqlite3"
+      File.rm! "./test.sqlite3"
     end
 
     test "can be dumped" do

--- a/test/support/structure.sql
+++ b/test/support/structure.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS "test" (
+CREATE TABLE "test" (
     "id" INTEGER PRIMARY KEY,
     "name" TEXT
 );

--- a/test/support/structure.sql
+++ b/test/support/structure.sql
@@ -2,3 +2,12 @@ CREATE TABLE "test" (
     "id" INTEGER PRIMARY KEY,
     "name" TEXT
 );
+CREATE TABLE "schema_migrations" (
+    "id" INTEGER PRIMARY KEY,
+    "version" TEXT
+);
+INSERT INTO "schema_migrations" ("version") VALUES (
+    "v1"
+), (
+    "v2"
+);

--- a/test/support/structure.sql
+++ b/test/support/structure.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS "test" (
+    "id" INTEGER PRIMARY KEY,
+    "name" TEXT
+);


### PR DESCRIPTION
This enables the use of `mix ecto.dump` and `mix ecto.load` to dump and load database schemas